### PR TITLE
Duplicate headers

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -192,7 +192,7 @@ function isJSONContent(headers) {
 /**
  * Return a new object with all field names of the headers lower-cased.
  *
- * Duplicates throw an error.
+ * Duplicates take the last value provided.
  */
 function headersFieldNamesToLowerCase(headers) {
   if (!isPlainObject(headers)) {
@@ -202,12 +202,12 @@ function headersFieldNamesToLowerCase(headers) {
   const lowerCaseHeaders = {}
   Object.entries(headers).forEach(([fieldName, fieldValue]) => {
     const key = fieldName.toLowerCase()
-    if (lowerCaseHeaders[key] !== undefined) {
-      throw Error(
-        `Failed to convert header keys to lower case due to field name conflict: ${key}`
-      )
+    const regex = new RegExp(fieldValue, 'i');
+    if(fieldValue instanceof RegExp && lowerCaseHeaders[key] === undefined) {
+      lowerCaseHeaders[key] = fieldValue
+    } else if (!regex.test(lowerCaseHeaders[key])) {
+      lowerCaseHeaders[key] = fieldValue
     }
-    lowerCaseHeaders[key] = fieldValue
   })
 
   return lowerCaseHeaders

--- a/tests/test_common.js
+++ b/tests/test_common.js
@@ -165,15 +165,17 @@ describe('`headersFieldNamesToLowerCase()`', () => {
     expect(input).to.deep.equal(inputClone) // assert the input is not mutated
   })
 
-  it('throws on conflicting keys', () => {
-    expect(() =>
-      common.headersFieldNamesToLowerCase({
-        HoSt: 'example.test',
-        HOST: 'example.test',
-      })
-    ).to.throw(
-      'Failed to convert header keys to lower case due to field name conflict: host'
-    )
+  it('handles duplicates of conflicting keys using last value provided', () => {
+    const results = common.headersFieldNamesToLowerCase({
+      hOsT: 'example.test',
+      HoSt: 'example.test',
+      HOST: 'final.example.test',
+    })
+    const expected = {
+      host: 'final.example.test',
+    }
+
+    expect(results).to.deep.equal(expected)
   })
 })
 


### PR DESCRIPTION
- Changed the `headersFieldNamesToLowerCase` method to handle duplicate headers taking the last value provided.
- Updated tests to reflect changes.
- Fixes: https://github.com/nock/nock/issues/2235
 